### PR TITLE
Use new color creation, fill/stroke assignment

### DIFF
--- a/document-sandbox-samples/communication-iframe-documentSandbox/package.json
+++ b/document-sandbox-samples/communication-iframe-documentSandbox/package.json
@@ -14,6 +14,6 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^1.0.0"
+        "@adobe/ccweb-add-on-scripts": "^1.1.0"
     }
 }

--- a/document-sandbox-samples/editor-apis/package.json
+++ b/document-sandbox-samples/editor-apis/package.json
@@ -14,6 +14,6 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^1.0.0"
+        "@adobe/ccweb-add-on-scripts": "^1.1.0"
     }
 }

--- a/document-sandbox-samples/editor-apis/src/code.js
+++ b/document-sandbox-samples/editor-apis/src/code.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import addOnSandboxSdk from "add-on-sdk-document-sandbox";
-import { editor, utils } from "express-document-sdk";
+import { editor, colorUtils } from "express-document-sdk";
 
 const { runtime } = addOnSandboxSdk.instance;
 
@@ -34,10 +34,10 @@ async function start() {
             text.translation = { x: 20, y: 400 };
             text.textAlignment = 2;
 
-            const rectFill = editor.createColorFill(utils.createColor(Math.random(), Math.random(), Math.random(), Math.random()));
-            const ellipseFill = editor.createColorFill(utils.createColor(Math.random(), Math.random(), Math.random(), Math.random()));
-            rectangle.fills.append(rectFill);
-            ellipse.fills.append(ellipseFill);
+            const rectFill = editor.createColorFill(colorUtils.fromRGB(Math.random(), Math.random(), Math.random(), Math.random()));
+            const ellipseFill = editor.createColorFill(colorUtils.fromRGB(Math.random(), Math.random(), Math.random(), Math.random()));
+            rectangle.fill = rectFill;
+            ellipse.fill = ellipseFill;
             insertionParent.children.append(rectangle);
             insertionParent.children.append(ellipse);
             insertionParent.children.append(text);

--- a/document-sandbox-samples/image-and-page/package.json
+++ b/document-sandbox-samples/image-and-page/package.json
@@ -14,6 +14,6 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^1.0.0"
+        "@adobe/ccweb-add-on-scripts": "^1.1.0"
     }
 }

--- a/document-sandbox-samples/image-and-page/src/code.js
+++ b/document-sandbox-samples/image-and-page/src/code.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import addOnSandboxSdk from "add-on-sdk-document-sandbox";
-import { editor, utils, constants } from "express-document-sdk";
+import { editor, colorUtils, constants } from "express-document-sdk";
 
 const { runtime } = addOnSandboxSdk.instance;
 
@@ -44,10 +44,10 @@ async function start() {
             text.translation = { x: 20, y: 400 };
             text.textAlignment = constants.TextAlignment.right;
 
-            const rectFill = editor.createColorFill(utils.createColor(Math.random(), Math.random(), Math.random(), Math.random()));
-            const ellipseFill = editor.createColorFill(utils.createColor(Math.random(), Math.random(), Math.random(), Math.random()));
-            rectangle.fills.append(rectFill);
-            ellipse.fills.append(ellipseFill);
+            const rectFill = editor.createColorFill(colorUtils.fromRGB(Math.random(), Math.random(), Math.random(), Math.random()));
+            const ellipseFill = editor.createColorFill(colorUtils.fromRGB(Math.random(), Math.random(), Math.random(), Math.random()));
+            rectangle.fill = rectFill;
+            ellipse.fill = ellipseFill;
             insertionParent.children.append(rectangle);
             insertionParent.children.append(ellipse);
             insertionParent.children.append(text);


### PR DESCRIPTION
Color creation is possible from `colorUtils` now
```
// Before
import { utils } from "express-document-sdk";
const color = utils.createColor(1, 0, 0);

// After
import { colorUtils } from "express-document-sdk";
// any of:
const color = colorUtils.fromRGB(1, 0, 0); // optional alpha
const color = colorUtils.fromRGB({ red: 1 , green: 0, blue: 0 }); // optional alpha
const color = colorUtils.fromHex("#ff0000");
const color = { red: 1, green: 0, blue: 0, alpha: 1 }; // mandatory alpha
```
`fills` is now `fill`
`strokes` is now `stroke`


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
