### PR TITLE
Fix express-stats-addon to display correct count of nodes

### DIFF
--- a/document-sandbox-samples/express-stats-addon/src/documentSandbox/utils.js
+++ b/document-sandbox-samples/express-stats-addon/src/documentSandbox/utils.js
@@ -19,13 +19,17 @@ const increaseCount = (obj, type) => {
   }
 };
 
+const hasChildren = (node) => {
+  return ([...node.allChildren] && [...node.allChildren].length > 0);
+}
+
 const getNodeData = (node, nodeData = {}) => {
   if (node.type === "MediaContainer") {
     return nodeData;
   }
 
   // Check if the current node has children and if they are not an empty array
-  if (node.allChildren && node.allChildren.length > 0) {
+if (hasChildren(node)) {
     // Iterate over all children using for..of
     for (const child of node.allChildren) {
       // Increase the count for the current type
@@ -35,14 +39,12 @@ const getNodeData = (node, nodeData = {}) => {
       // ... unless it's a MediaContainer
       if (
         child.type !== "MediaContainer" &&
-        child.allChildren &&
-        child.allChildren.length > 0
+        hasChildren(child)
       ) {
         getNodeData(child, nodeData);
       }
     }
   }
-
   return nodeData;
 };
 


### PR DESCRIPTION
## Description

This line of code looks wrong: https://github.com/AdobeDocs/express-add-on-samples/blob/main/document-sandbox-samples/express-stats-addon/src/documentSandbox/utils.js#L28
It’s assuming allChildren is an array with .length, when it’s not.

Made the necessary changes in the express-stats-addon

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
