### PR TITLE
Reduce memory overhead

### DIFF
--- a/marketplace/gradients/src/manifest.json
+++ b/marketplace/gradients/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "testId": "63ca98b1-9551-4eb7-aa4f-dc494c79f23d",
     "name": "Gradients",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "manifestVersion": 2,
     "requirements": {
         "apps": [

--- a/marketplace/gradients/src/ui/components/gradient/ConicGradient.ts
+++ b/marketplace/gradients/src/ui/components/gradient/ConicGradient.ts
@@ -28,11 +28,10 @@ export class ConicGradient extends GradientBase<ConicFillDirection> {
     }
 
     protected override getGradientImage(fillDirection: ConicFillDirection): string {
-        const canvas = document.createElement("canvas");
-        canvas.width = this.width;
-        canvas.height = this.height;
+        this._canvas.width = this.width;
+        this._canvas.height = this.height;
 
-        const canvasContext = canvas.getContext("2d");
+        const canvasContext = this._canvas.getContext("2d");
         const canvasGradient = this._getGradient(canvasContext, fillDirection);
 
         const stop1 = Number((this.stop1 / MAX_RANGE).toFixed(1));
@@ -44,7 +43,7 @@ export class ConicGradient extends GradientBase<ConicFillDirection> {
         canvasContext.fillStyle = canvasGradient;
         canvasContext.fillRect(0, 0, this.width, this.height);
 
-        return canvas.toDataURL("image/png");
+        return this._canvas.toDataURL("image/png");
     }
 
     private _getGradient(canvasContext: CanvasRenderingContext2D, fillDirection: ConicFillDirection): CanvasGradient {

--- a/marketplace/gradients/src/ui/components/gradient/ConicGradient.ts
+++ b/marketplace/gradients/src/ui/components/gradient/ConicGradient.ts
@@ -28,10 +28,10 @@ export class ConicGradient extends GradientBase<ConicFillDirection> {
     }
 
     protected override getGradientImage(fillDirection: ConicFillDirection): string {
-        this._canvas.width = this.width;
-        this._canvas.height = this.height;
+        this.canvas.width = this.width;
+        this.canvas.height = this.height;
 
-        const canvasContext = this._canvas.getContext("2d");
+        const canvasContext = this.canvas.getContext("2d");
         const canvasGradient = this._getGradient(canvasContext, fillDirection);
 
         const stop1 = Number((this.stop1 / MAX_RANGE).toFixed(1));
@@ -43,7 +43,7 @@ export class ConicGradient extends GradientBase<ConicFillDirection> {
         canvasContext.fillStyle = canvasGradient;
         canvasContext.fillRect(0, 0, this.width, this.height);
 
-        return this._canvas.toDataURL("image/png");
+        return this.canvas.toDataURL("image/png");
     }
 
     private _getGradient(canvasContext: CanvasRenderingContext2D, fillDirection: ConicFillDirection): CanvasGradient {

--- a/marketplace/gradients/src/ui/components/gradient/GradientBase.ts
+++ b/marketplace/gradients/src/ui/components/gradient/GradientBase.ts
@@ -43,6 +43,8 @@ export abstract class GradientBase<T extends FillDirection> extends LitElement {
     @state()
     private _fillDirection: T;
 
+    protected _canvas: HTMLCanvasElement;
+
     static get styles() {
         return style;
     }
@@ -50,6 +52,7 @@ export abstract class GradientBase<T extends FillDirection> extends LitElement {
     constructor(defaultFillDirection: T) {
         super();
         this._fillDirection = defaultFillDirection;
+        this._canvas = document.createElement("canvas");
     }
 
     protected abstract getAllDirections(): string[];

--- a/marketplace/gradients/src/ui/components/gradient/GradientBase.ts
+++ b/marketplace/gradients/src/ui/components/gradient/GradientBase.ts
@@ -19,6 +19,9 @@ import { style } from "./Gradient.css";
 import { FillDirection } from "./GradientType";
 
 export abstract class GradientBase<T extends FillDirection> extends LitElement {
+    @property({ type: HTMLCanvasElement })
+    canvas!: HTMLCanvasElement;
+
     @property({ type: String })
     startingColor!: string;
 
@@ -43,8 +46,6 @@ export abstract class GradientBase<T extends FillDirection> extends LitElement {
     @state()
     private _fillDirection: T;
 
-    protected _canvas: HTMLCanvasElement;
-
     static get styles() {
         return style;
     }
@@ -52,7 +53,6 @@ export abstract class GradientBase<T extends FillDirection> extends LitElement {
     constructor(defaultFillDirection: T) {
         super();
         this._fillDirection = defaultFillDirection;
-        this._canvas = document.createElement("canvas");
     }
 
     protected abstract getAllDirections(): string[];

--- a/marketplace/gradients/src/ui/components/gradient/GradientForm.ts
+++ b/marketplace/gradients/src/ui/components/gradient/GradientForm.ts
@@ -66,17 +66,16 @@ export class GradientForm extends LitElement {
     private _gradientImageUrl: string;
 
     private _previewImage: HTMLImageElement;
+    protected _canvas: HTMLCanvasElement;
 
     static get styles() {
         return style;
     }
 
-    constructor() {
-        super();
-        this._previewImage = document.createElement("img");
-    }
-
     async firstUpdated(): Promise<void> {
+        this._previewImage = document.createElement("img");
+        this._canvas = document.createElement("canvas");
+
         const { runtime } = this.addOnUISdk.instance;
         this._sandboxApi = await runtime.apiProxy(RuntimeType.documentSandbox);
 
@@ -175,6 +174,7 @@ export class GradientForm extends LitElement {
         switch (this._activeGradientType) {
             case GradientType.Linear: {
                 activeGradient = html`<add-on-linear-gradient
+                    .canvas=${this._canvas}
                     .startingColor=${this._startingColor}
                     .endingColor=${this._endingColor}
                     .width=${this._pageSize.width}
@@ -188,6 +188,7 @@ export class GradientForm extends LitElement {
             }
             case GradientType.Radial: {
                 activeGradient = html`<add-on-radial-gradient
+                    .canvas=${this._canvas}
                     .startingColor=${this._startingColor}
                     .endingColor=${this._endingColor}
                     .width=${this._pageSize.width}
@@ -201,6 +202,7 @@ export class GradientForm extends LitElement {
             }
             case GradientType.Conic: {
                 activeGradient = html`<add-on-conic-gradient
+                    .canvas=${this._canvas}
                     .startingColor=${this._startingColor}
                     .endingColor=${this._endingColor}
                     .width=${this._pageSize.width}

--- a/marketplace/gradients/src/ui/components/gradient/GradientForm.ts
+++ b/marketplace/gradients/src/ui/components/gradient/GradientForm.ts
@@ -65,8 +65,15 @@ export class GradientForm extends LitElement {
     @state()
     private _gradientImageUrl: string;
 
+    private _previewImage: HTMLImageElement;
+
     static get styles() {
         return style;
+    }
+
+    constructor() {
+        super();
+        this._previewImage = document.createElement("img");
     }
 
     async firstUpdated(): Promise<void> {
@@ -120,21 +127,20 @@ export class GradientForm extends LitElement {
     }
 
     private _previewGradient(): Promise<void> {
-        if (this._pageSize === undefined) {
+        if (this._pageSize === undefined || this._gradientImageUrl === undefined) {
             return;
         }
 
-        const previewImage = document.createElement("img");
-        previewImage.setAttribute("src", this._gradientImageUrl);
+        this._previewImage.setAttribute("src", this._gradientImageUrl);
 
         const previewImageScale = Number((this._pageSize.width / PREVIEW_IMAGE_WIDTH).toFixed(2));
         const previewImageHeight = Math.round(this._pageSize.height / previewImageScale);
 
-        previewImage.style.width = `${PREVIEW_IMAGE_WIDTH}px`;
-        previewImage.style.height = `${previewImageHeight}px`;
+        this._previewImage.style.width = `${PREVIEW_IMAGE_WIDTH}px`;
+        this._previewImage.style.height = `${previewImageHeight}px`;
 
         const previewContainer = this.shadowRoot.getElementById("preview-container");
-        previewContainer.replaceChildren(previewImage);
+        previewContainer.replaceChildren(this._previewImage);
     }
 
     private _reset() {

--- a/marketplace/gradients/src/ui/components/gradient/LinearGradient.ts
+++ b/marketplace/gradients/src/ui/components/gradient/LinearGradient.ts
@@ -28,11 +28,10 @@ export class LinearGradient extends GradientBase<LinearFillDirection> {
     }
 
     protected override getGradientImage(fillDirection: LinearFillDirection): string {
-        const canvas = document.createElement("canvas");
-        canvas.width = this.width;
-        canvas.height = this.height;
+        this._canvas.width = this.width;
+        this._canvas.height = this.height;
 
-        const canvasContext = canvas.getContext("2d");
+        const canvasContext = this._canvas.getContext("2d");
         const canvasGradient = this._getGradient(canvasContext, fillDirection);
 
         const stop1 = Number((this.stop1 / MAX_RANGE).toFixed(1));
@@ -44,7 +43,7 @@ export class LinearGradient extends GradientBase<LinearFillDirection> {
         canvasContext.fillStyle = canvasGradient;
         canvasContext.fillRect(0, 0, this.width, this.height);
 
-        return canvas.toDataURL("image/png");
+        return this._canvas.toDataURL("image/png");
     }
 
     private _getGradient(canvasContext: CanvasRenderingContext2D, fillDirection: LinearFillDirection): CanvasGradient {

--- a/marketplace/gradients/src/ui/components/gradient/LinearGradient.ts
+++ b/marketplace/gradients/src/ui/components/gradient/LinearGradient.ts
@@ -28,10 +28,10 @@ export class LinearGradient extends GradientBase<LinearFillDirection> {
     }
 
     protected override getGradientImage(fillDirection: LinearFillDirection): string {
-        this._canvas.width = this.width;
-        this._canvas.height = this.height;
+        this.canvas.width = this.width;
+        this.canvas.height = this.height;
 
-        const canvasContext = this._canvas.getContext("2d");
+        const canvasContext = this.canvas.getContext("2d");
         const canvasGradient = this._getGradient(canvasContext, fillDirection);
 
         const stop1 = Number((this.stop1 / MAX_RANGE).toFixed(1));
@@ -43,7 +43,7 @@ export class LinearGradient extends GradientBase<LinearFillDirection> {
         canvasContext.fillStyle = canvasGradient;
         canvasContext.fillRect(0, 0, this.width, this.height);
 
-        return this._canvas.toDataURL("image/png");
+        return this.canvas.toDataURL("image/png");
     }
 
     private _getGradient(canvasContext: CanvasRenderingContext2D, fillDirection: LinearFillDirection): CanvasGradient {

--- a/marketplace/gradients/src/ui/components/gradient/RadialGradient.ts
+++ b/marketplace/gradients/src/ui/components/gradient/RadialGradient.ts
@@ -28,11 +28,10 @@ export class RadialGradient extends GradientBase<RadialFillDirection> {
     }
 
     protected override getGradientImage(fillDirection: RadialFillDirection): string {
-        const canvas = document.createElement("canvas");
-        canvas.width = this.width;
-        canvas.height = this.height;
+        this._canvas.width = this.width;
+        this._canvas.height = this.height;
 
-        const canvasContext = canvas.getContext("2d");
+        const canvasContext = this._canvas.getContext("2d");
         const canvasGradient = this._getGradient(canvasContext, fillDirection);
 
         const stop1 = Number((this.stop1 / MAX_RANGE).toFixed(1));
@@ -44,7 +43,7 @@ export class RadialGradient extends GradientBase<RadialFillDirection> {
         canvasContext.fillStyle = canvasGradient;
         canvasContext.fillRect(0, 0, this.width, this.height);
 
-        return canvas.toDataURL("image/png");
+        return this._canvas.toDataURL("image/png");
     }
 
     private _getGradient(canvasContext: CanvasRenderingContext2D, fillDirection: RadialFillDirection): CanvasGradient {

--- a/marketplace/gradients/src/ui/components/gradient/RadialGradient.ts
+++ b/marketplace/gradients/src/ui/components/gradient/RadialGradient.ts
@@ -28,10 +28,10 @@ export class RadialGradient extends GradientBase<RadialFillDirection> {
     }
 
     protected override getGradientImage(fillDirection: RadialFillDirection): string {
-        this._canvas.width = this.width;
-        this._canvas.height = this.height;
+        this.canvas.width = this.width;
+        this.canvas.height = this.height;
 
-        const canvasContext = this._canvas.getContext("2d");
+        const canvasContext = this.canvas.getContext("2d");
         const canvasGradient = this._getGradient(canvasContext, fillDirection);
 
         const stop1 = Number((this.stop1 / MAX_RANGE).toFixed(1));
@@ -43,7 +43,7 @@ export class RadialGradient extends GradientBase<RadialFillDirection> {
         canvasContext.fillStyle = canvasGradient;
         canvasContext.fillRect(0, 0, this.width, this.height);
 
-        return this._canvas.toDataURL("image/png");
+        return this.canvas.toDataURL("image/png");
     }
 
     private _getGradient(canvasContext: CanvasRenderingContext2D, fillDirection: RadialFillDirection): CanvasGradient {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Reuse the same DOM image element and canvas element for gradient preview and image. Re-creating these elements everytime, for a different gradient configuration could lead to failures in generating the gradient preview/image.

- Short-circuit invalid code paths that led to console errors.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
