### PR TITLE
Bumping Express CLI to newer version

### DIFF
--- a/contributed/pix/package.json
+++ b/contributed/pix/package.json
@@ -37,7 +37,7 @@
         "react-dom": "18.2.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.18.13",
         "@babel/preset-env": "7.18.10",
         "@babel/preset-react": "7.18.6",

--- a/contributed/swc-react-theme-sampler/package.json
+++ b/contributed/swc-react-theme-sampler/package.json
@@ -29,7 +29,7 @@
         "@swc-react/theme": "^0.34.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.18.13",
         "@babel/preset-env": "7.18.10",
         "@babel/preset-react": "7.18.6",

--- a/contributed/swc/package.json
+++ b/contributed/swc/package.json
@@ -23,7 +23,7 @@
         "@spectrum-web-components/theme": "^0.14.9"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.18.13",
         "@babel/preset-env": "7.18.10",
         "babel-loader": "8.2.5",

--- a/document-sandbox-samples/communication-iframe-documentSandbox/package.json
+++ b/document-sandbox-samples/communication-iframe-documentSandbox/package.json
@@ -14,6 +14,6 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0"
+        "@adobe/ccweb-add-on-scripts": "^3.6.0"
     }
 }

--- a/document-sandbox-samples/editor-apis/package.json
+++ b/document-sandbox-samples/editor-apis/package.json
@@ -14,6 +14,6 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0"
+        "@adobe/ccweb-add-on-scripts": "^3.6.0"
     }
 }

--- a/document-sandbox-samples/express-addon-document-api-template/package.json
+++ b/document-sandbox-samples/express-addon-document-api-template/package.json
@@ -15,7 +15,7 @@
         "Adobe Express"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "^7.23.0",
         "@babel/preset-env": "^7.22.20",
         "babel-loader": "^9.1.3",

--- a/document-sandbox-samples/express-dimensions-addon/express-dimensions-end/package.json
+++ b/document-sandbox-samples/express-dimensions-addon/express-dimensions-end/package.json
@@ -15,7 +15,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@types/adobe__ccweb-add-on-sdk": "^1.3.0",
         "@babel/core": "^7.23.5",
         "@babel/preset-env": "^7.23.5",

--- a/document-sandbox-samples/express-dimensions-addon/express-dimensions-start/package.json
+++ b/document-sandbox-samples/express-dimensions-addon/express-dimensions-start/package.json
@@ -15,7 +15,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@types/adobe__ccweb-add-on-sdk": "^1.3.0",
         "@babel/core": "^7.23.5",
         "@babel/preset-env": "^7.23.5",

--- a/document-sandbox-samples/express-stats-addon/package.json
+++ b/document-sandbox-samples/express-stats-addon/package.json
@@ -15,7 +15,7 @@
         "Adobe Express"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "^7.23.0",
         "@babel/preset-env": "^7.22.20",
         "babel-loader": "^9.1.3",

--- a/document-sandbox-samples/image-and-page/package.json
+++ b/document-sandbox-samples/image-and-page/package.json
@@ -14,6 +14,6 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0"
+        "@adobe/ccweb-add-on-scripts": "^3.6.0"
     }
 }

--- a/document-sandbox-samples/per-element-metadata/package.json
+++ b/document-sandbox-samples/per-element-metadata/package.json
@@ -15,7 +15,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
-        "@adobe/ccweb-add-on-sdk-types": "^1.5.0"
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
+        "@adobe/ccweb-add-on-sdk-types": "^1.27.0"
     }
 }

--- a/marketplace/giphy/package.json
+++ b/marketplace/giphy/package.json
@@ -15,7 +15,7 @@
     "panel"
   ],
   "devDependencies": {
-    "@adobe/ccweb-add-on-scripts": "^2.0.0",
+    "@adobe/ccweb-add-on-scripts": "^3.6.0",
     "prettier": "2.6.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0"

--- a/marketplace/gradients/package.json
+++ b/marketplace/gradients/package.json
@@ -28,7 +28,7 @@
         "lit": "2.8.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@adobe/ccweb-add-on-sdk-types": "^1.3.0",
         "copy-webpack-plugin": "11.0.0",
         "html-webpack-plugin": "5.5.3",

--- a/marketplace/qrcode/package.json
+++ b/marketplace/qrcode/package.json
@@ -14,7 +14,7 @@
         "add-on"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "prettier": "2.6.0"
     }
 }

--- a/samples/audio-recording-add-on/package.json
+++ b/samples/audio-recording-add-on/package.json
@@ -16,7 +16,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "prettier": "2.6.0"
     }
 }

--- a/samples/connect-to-google-photos/package.json
+++ b/samples/connect-to-google-photos/package.json
@@ -28,7 +28,7 @@
         "react-masonry-css": "1.0.16"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.23.3",
         "@babel/eslint-parser": "7.24.7",
         "@babel/preset-env": "7.23.3",

--- a/samples/dialog-add-on/package.json
+++ b/samples/dialog-add-on/package.json
@@ -27,7 +27,7 @@
         "react": "18.2.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.18.13",
         "@babel/preset-env": "7.18.10",
         "@babel/preset-react": "7.18.6",

--- a/samples/export-sample/package.json
+++ b/samples/export-sample/package.json
@@ -28,7 +28,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "copy-webpack-plugin": "^9.1.0",
         "css-loader": "^6.5.1",
         "html-webpack-plugin": "5.5.0",

--- a/samples/get-started/package.json
+++ b/samples/get-started/package.json
@@ -14,7 +14,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "prettier": "2.6.0"
     }
 }

--- a/samples/import-images-from-local/package.json
+++ b/samples/import-images-from-local/package.json
@@ -14,7 +14,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "prettier": "2.6.0"
     }
 }

--- a/samples/import-images-using-oauth/package.json
+++ b/samples/import-images-using-oauth/package.json
@@ -24,7 +24,7 @@
         "react": "18.2.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.18.13",
         "@babel/eslint-parser": "7.18.9",
         "@babel/preset-env": "7.18.10",

--- a/samples/licensed-addon/package.json
+++ b/samples/licensed-addon/package.json
@@ -25,7 +25,7 @@
         "react-dom": "18.2.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@babel/core": "7.22.19",
         "@babel/preset-env": "7.22.15",
         "@babel/preset-react": "7.22.15",

--- a/samples/use-client-storage/package.json
+++ b/samples/use-client-storage/package.json
@@ -14,7 +14,7 @@
         "panel"
     ],
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "copy-webpack-plugin": "11.0.0",
         "html-webpack-plugin": "5.5.0",
         "prettier": "2.6.0",

--- a/test-samples/react-typescript-mocha/package.json
+++ b/test-samples/react-typescript-mocha/package.json
@@ -24,7 +24,7 @@
         "react": "18.2.0"
     },
     "devDependencies": {
-        "@adobe/ccweb-add-on-scripts": "^2.0.0",
+        "@adobe/ccweb-add-on-scripts": "^3.6.0",
         "@testing-library/dom": "10.0.0",
         "@testing-library/react": "15.0.2",
         "@testing-library/user-event": "14.5.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates `@adobe/ccweb-add-on-scripts` version for all samples. 
This helps reduce risk of the devcert being generated in an incorrect location and causing SSL issues (applies to versions predating `3.0.0`).

## Motivation and Context

Ensures a smooth experience for developers whose entry point into add-on development is running a pre-built sample instead of creating a new one using the CLI.

## How Has This Been Tested?

- Removed local folder containing devcert
- Updated `@adobe/ccweb-add-on-scripts` version to `3.6.0`
- Ran `npm install`, `npm run build` and `npm run start`
- Side loaded add-on in Express

I repeated this test across three separate projects --"per-element-metadata", "import-images-using-oauth", and "image-in-page"

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
